### PR TITLE
changed dumb-init location to correspond as in landoop/fast-data-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ ADD supervisord.conf /etc/
 RUN chmod +x /usr/local/bin/setup-and-run-connect-distributed.sh
 
 EXPOSE 8083
-ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/usr/local/bin/setup-and-run-connect-distributed.sh"]


### PR DESCRIPTION
changed dumb-init location to correspond as in landoop/fast-data-dev

notice that the latest version of fast-data-dev moved dumb-init from /usr/local/bin to /usr/bin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/fast-data-connect-cluster/3)
<!-- Reviewable:end -->
